### PR TITLE
A few proposals / changes / fixes (#37)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.15.1-R0.1-SNAPSHOT</version>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/antiperson/stackmob/commands/Commands.java
+++ b/src/main/java/uk/antiperson/stackmob/commands/Commands.java
@@ -123,6 +123,11 @@ public class Commands implements CommandExecutor, TabCompleter {
         if (strings.length == 1) {
             List<String> args = new ArrayList<>();
             for (SubCommand subCommand : subCommands) {
+                String commandString = subCommand.getCommand();
+
+                if (!commandString.toLowerCase().startsWith(strings[0].toLowerCase())) {
+                    continue;
+                }
                 args.add(subCommand.getCommand());
             }
             return args;
@@ -135,7 +140,12 @@ public class Commands implements CommandExecutor, TabCompleter {
                 return null;
             }
             CommandArgument commandArgument = subCommand.getArguments()[strings.length - 2];
-            return commandArgument.getExpectedArguments();
+
+            List<String> expectedArguments = new LinkedList<>(commandArgument.getExpectedArguments());
+            expectedArguments.removeIf(possibleArgument -> !possibleArgument.toLowerCase().startsWith(strings[strings.length - 1].toLowerCase()));
+            Collections.sort(expectedArguments);
+
+            return expectedArguments;
         }
         return null;
     }

--- a/src/main/java/uk/antiperson/stackmob/commands/subcommands/SpawnStack.java
+++ b/src/main/java/uk/antiperson/stackmob/commands/subcommands/SpawnStack.java
@@ -22,7 +22,7 @@ public class SpawnStack extends SubCommand {
         Player player = (Player) sender.getSender();
         Entity entity = player.getWorld().spawnEntity(player.getLocation(), EntityType.valueOf(args[0].toUpperCase()));
         StackEntity stackEntity = sm.getEntityManager().getStackEntity((LivingEntity) entity);
-        stackEntity.setSize(Integer.valueOf(args[1]));
+        stackEntity.setSize(Integer.parseInt(args[1]));
         sender.sendSuccess("A new stack has been spawned.");
         return false;
     }

--- a/src/main/java/uk/antiperson/stackmob/commands/subcommands/Upgrade.java
+++ b/src/main/java/uk/antiperson/stackmob/commands/subcommands/Upgrade.java
@@ -1,6 +1,5 @@
 package uk.antiperson.stackmob.commands.subcommands;
 
-import org.bukkit.command.CommandSender;
 import uk.antiperson.stackmob.StackMob;
 import uk.antiperson.stackmob.commands.CommandMetadata;
 import uk.antiperson.stackmob.commands.SubCommand;

--- a/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/StackEntity.java
@@ -43,6 +43,7 @@ public class StackEntity {
     public void removeStackData() {
         entity.getPersistentDataContainer().remove(sm.getStackKey());
         getTag().update();
+        entity.setCustomNameVisible(false);
     }
 
     public boolean shouldWait(CreatureSpawnEvent.SpawnReason spawnReason) {

--- a/src/main/java/uk/antiperson/stackmob/entity/Tag.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/Tag.java
@@ -21,6 +21,7 @@ public class Tag {
         int threshold = sm.getMainConfig().getTagThreshold(entity.getType());
         if (stackEntity.getSize() <= threshold) {
             entity.setCustomName(null);
+            entity.setCustomNameVisible(false);
             return;
         }
         String typeString = sm.getEntityTranslation().getTranslatedName(entity.getType());

--- a/src/main/java/uk/antiperson/stackmob/entity/traits/TraitManager.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/traits/TraitManager.java
@@ -31,6 +31,8 @@ public class TraitManager {
         registerTrait(LoveMode.class);
         registerTrait(DrownedItem.class);
         registerTrait(ZombieBaby.class);
+        registerTrait(BeeNectar.class);
+        registerTrait(BeeStung.class);
     }
 
     /**

--- a/src/main/java/uk/antiperson/stackmob/entity/traits/trait/BeeNectar.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/traits/trait/BeeNectar.java
@@ -1,0 +1,19 @@
+package uk.antiperson.stackmob.entity.traits.trait;
+
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.LivingEntity;
+import uk.antiperson.stackmob.entity.traits.Trait;
+import uk.antiperson.stackmob.entity.traits.TraitMetadata;
+
+@TraitMetadata(entity = Bee.class, path = "bee-nectar")
+public class BeeNectar implements Trait {
+    @Override
+    public boolean checkTrait(LivingEntity first, LivingEntity nearby) {
+        return ((Bee) first).hasNectar() != ((Bee) nearby).hasNectar();
+    }
+
+    @Override
+    public void applyTrait(LivingEntity spawned, LivingEntity dead) {
+        ((Bee) spawned).setHasNectar(((Bee) dead).hasNectar());
+    }
+}

--- a/src/main/java/uk/antiperson/stackmob/entity/traits/trait/BeeStung.java
+++ b/src/main/java/uk/antiperson/stackmob/entity/traits/trait/BeeStung.java
@@ -1,0 +1,20 @@
+package uk.antiperson.stackmob.entity.traits.trait;
+
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.LivingEntity;
+import uk.antiperson.stackmob.entity.traits.Trait;
+import uk.antiperson.stackmob.entity.traits.TraitMetadata;
+
+@TraitMetadata(entity = Bee.class, path = "bee-stung")
+public class BeeStung implements Trait {
+    @Override
+    public boolean checkTrait(LivingEntity first, LivingEntity nearby) {
+        return ((Bee) first).hasStung() != ((Bee) nearby).hasStung();
+    }
+
+    @Override
+    public void applyTrait(LivingEntity spawned, LivingEntity dead) {
+        ((Bee) spawned).setHasStung(((Bee) dead).hasStung());
+    }
+}
+

--- a/src/main/java/uk/antiperson/stackmob/listeners/DeathListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/DeathListener.java
@@ -32,7 +32,7 @@ public class DeathListener implements Listener {
         }
         DeathMethod deathMethod = calculateDeath(stackEntity);
         int deathStep = Math.min(stackEntity.getSize(), deathMethod.calculateStep());
-        if (deathStep < stackEntity.getSize()) {
+        if (deathStep > 0 && deathStep < stackEntity.getSize()) {
             StackEntity spawned = stackEntity.duplicate();
             spawned.setSize(stackEntity.getSize() - deathStep);
             deathMethod.onSpawn(spawned);

--- a/src/main/java/uk/antiperson/stackmob/listeners/DropListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/DropListener.java
@@ -1,8 +1,7 @@
 package uk.antiperson.stackmob.listeners;
 
-import org.bukkit.entity.Chicken;
+import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Turtle;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDropItemEvent;
@@ -23,7 +22,7 @@ public class DropListener implements Listener {
 
     @EventHandler
     public void onDropListener(EntityDropItemEvent event) {
-        if (!((event.getEntity() instanceof Chicken) || (event.getEntity() instanceof Turtle))) {
+        if ((event.getItemDrop().getItemStack().getType() != Material.EGG) || (event.getItemDrop().getItemStack().getType() != Material.SCUTE)) {
             return;
         }
         StackEntity entity = sm.getEntityManager().getStackEntity((LivingEntity) event.getEntity());

--- a/src/main/java/uk/antiperson/stackmob/listeners/TagInteractListener.java
+++ b/src/main/java/uk/antiperson/stackmob/listeners/TagInteractListener.java
@@ -32,8 +32,10 @@ public class TagInteractListener implements Listener {
         }
         StackEntity stackEntity = sm.getEntityManager().getStackEntity((LivingEntity) event.getRightClicked());
         if (stackEntity.isSingle()) {
+            stackEntity.removeStackData();
             return;
         }
         stackEntity.slice();
+        stackEntity.removeStackData();
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,6 +65,8 @@ traits:
   cat-type: true
   mooshroom-variant: true
   fox-type: true
+  bee-nectar: true
+  bee-stung: true
 
 # Prevent stacked mobs from targeting players.
 # Similar to no-ai, but allows for movement of entities.


### PR DESCRIPTION
* Minor changes / proposals :
- Removed unused import
- Changed to parseInt in spawn subcommand (should be better)
- A renaamed entity shouldn't be stacked again -> stack data deletion
- 2 new traits for Bees, I think they are interesting as long as they prevent quick production of honey or a massive bee attack ^^

* Revert "Minor changes / proposals : - Removed unused import - Changed to parseInt in spawn subcommand (should be better) - A renaamed entity shouldn't be stacked again -> stack data deletion - 2 new traits for Bees, I think they are interesting as long as they prevent quick production of honey or a massive bee attack ^^"

* fixup! Minor changes / proposals : - Removed unused import - Changed to parseInt in spawn subcommand (should be better) - A renaamed entity shouldn't be stacked again -> stack data deletion - 2 new traits for Bees, I think they are interesting as long as they prevent quick production of honey or a massive bee attack ^^

* Only show the tag of a renamed entity on hover (as vanilla's behaviour)

* Moved the change of the tag visibility to the #removeStackData method.

* Minor updates
- Update to Paper 1.15.2 for a future PR
- Improve TabCompletion to suggest according to the arg's beginning

* Fix error on /kill @e, fix minor things about names

* Finally fixed https://github.com/Nathat23/StackMob-5/issues/36
- Base drop duplication on Item and not on the entity because this event is called with leads